### PR TITLE
perf(fzf): 预热 shell 执行通道，消除 :Files 首次冷启动延迟

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .vim/
 .tags
 *.temp.html
+.omc
+.claude

--- a/.vimrc
+++ b/.vimrc
@@ -1245,6 +1245,9 @@ augroup END
 
             nnoremap <c-p> :Files<Cr>
 
+            " Warm up :! to avoid first :Files cold start delay
+            silent! call system('true')
+
             unlet g:fzf_folder_via_git
             unlet g:fzf_in_scoop
         endif


### PR DESCRIPTION
## 问题

1. `:Files`（Ctrl+P）在大项目中速度慢
2. 即使小项目，第一次 `:Files` 也很慢，第二次才快

## 根因

1. **大项目慢**：`FZF_DEFAULT_COMMAND` 使用 `rg --files --hidden`，扫描范围过大；且未安装更快的 `fd`
2. **首次冷启动慢**：Vim 首次 `:!` 外部命令需要分配伪终端、加载 shell 二进制，导致首次调用延迟

## 修改内容

| 文件 | 改动 |
|------|------|
| `.vimrc` | 添加 `silent! call system('true')` 预热 shell 执行通道 |
| `.gitignore` | 添加 `.omc`、`.claude` 忽略规则 |

## 附带操作（非代码变更）

- `brew install fd`：安装后 oh-my-zsh fzf 插件自动切换 `FZF_DEFAULT_COMMAND` 为 `fd --type f --hidden --exclude .git`

## 验证

重启 Vim + 终端后，首次 `Ctrl+P` 响应速度应显著提升。