### PR TITLE
revert(fzf): 移除无效的 call system('true') 预热

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1245,9 +1245,6 @@ augroup END
 
             nnoremap <c-p> :Files<Cr>
 
-            " Warm up :! to avoid first :Files cold start delay
-            silent! call system('true')
-
             unlet g:fzf_folder_via_git
             unlet g:fzf_in_scoop
         endif


### PR DESCRIPTION
## 原因

`call system('true')` 预热方案有两个问题：

1. **无效**：对首次 `:Files` 冷启动延迟无改善
2. **副作用**：`system()` 同步阻塞，导致 GVim 启动变慢

## 改动

移除 `.vimrc` 中 fzf 配置块内的预热代码。