### PR TITLE
fix(fzf): 修复 brew fzf runtimepath 路径

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1231,7 +1231,7 @@ augroup END
 
             if filereadable('/opt/homebrew/bin/fzf')
                 " for mac os,  fzf installed by brew
-                set runtimepath+=/opt/homebrew/bin
+                set runtimepath+=/opt/homebrew/opt/fzf
             elseif isdirectory(g:fzf_in_scoop)
                 " for windows, fzf installed by scoop
                 execute 'set runtimepath+=' . g:fzf_in_scoop


### PR DESCRIPTION
## 问题

brew 安装 fzf 后，`.vimrc` 中 runtimepath 指向了错误路径 `/opt/homebrew/bin`（只有二进制），导致 Vim 找不到 fzf 插件文件。

## 修改

| 文件 | 改动 |
|------|------|
| `.vimrc` | `runtimepath` 从 `/opt/homebrew/bin` 修正为 `/opt/homebrew/opt/fzf` |

## 背景

配合 fzf 从 git 安装（0.60.3）迁移到 brew 管理（0.70.0），brew fzf 的 Vim 插件文件位于 `/opt/homebrew/opt/fzf/`。